### PR TITLE
Return a 403 Forbidden response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>uk.nhs.cactus</groupId>
   <artifactId>common</artifactId>
-  <version>0.0.5.1</version>
+  <version>0.0.5.2</version>
   <packaging>jar</packaging>
 
   <parent>

--- a/src/main/java/uk/nhs/cactus/common/security/TokenAuthenticationService.java
+++ b/src/main/java/uk/nhs/cactus/common/security/TokenAuthenticationService.java
@@ -73,7 +73,7 @@ public class TokenAuthenticationService {
    *                authentication token is present
    */
   public void requireSupplierId(String supplierId) {
-    if (requireSupplierId().equals(supplierId)) {
+    if (!requireSupplierId().equals(supplierId)) {
       throw new ForbiddenOperationException("Forbidden");
     }
   }

--- a/src/main/java/uk/nhs/cactus/common/security/TokenAuthenticationService.java
+++ b/src/main/java/uk/nhs/cactus/common/security/TokenAuthenticationService.java
@@ -1,6 +1,7 @@
 package uk.nhs.cactus.common.security;
 
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
+import ca.uhn.fhir.rest.server.exceptions.ForbiddenOperationException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.MalformedJwtException;
@@ -65,22 +66,23 @@ public class TokenAuthenticationService {
   }
 
   /**
-   * Throws an {@link ca.uhn.fhir.rest.server.exceptions.AuthenticationException} if the provided
-   * supplierId does not match the current request's authentication token
-   *
    * @param supplierId identifies the expected supplier
+   * @throws {@link ca.uhn.fhir.rest.server.exceptions.ForbiddenOperationException} if the provided
+   *                supplierId does not match the current request's authentication token
+   * @throws {@link ca.uhn.fhir.rest.server.exceptions.AuthenticationException} if no valid
+   *                authentication token is present
    */
   public void requireSupplierId(String supplierId) {
-    if (!getCurrentSupplierId().map(supplierId::equals).orElse(false)) {
-      throw new AuthenticationException();
+    if (requireSupplierId().equals(supplierId)) {
+      throw new ForbiddenOperationException("Forbidden");
     }
   }
 
   /**
-   * Requires that a supplier is currently authenticated, throwing an {@link
-   * AuthenticationException} if not.
+   * Requires that a supplier is currently authenticated
    *
    * @return the current supplierId
+   * @throws {@link AuthenticationException} if not able to authenticate
    */
   public String requireSupplierId() {
     return getCurrentSupplierId().orElseThrow(AuthenticationException::new);


### PR DESCRIPTION
Throws a ForbiddenException (and hence 403 response code) if the user is authenticated but does not match the expected supplier ID